### PR TITLE
Use new configurator

### DIFF
--- a/Universal THCRAP Launcher/MainForm.cs
+++ b/Universal THCRAP Launcher/MainForm.cs
@@ -402,7 +402,7 @@ namespace Universal_THCRAP_Launcher
             MessageBox.Show(I18N.LangResource.popup.hideLauncher.text?.ToString(),
                             I18N.LangResource.popup.hideLauncher.caption?.ToString(), MessageBoxButtons.OK,
                             MessageBoxIcon.Information);
-            Process p = Process.Start("thcrap_configure.exe");
+            Process p = Process.Start("thcrap_configure_v3.exe");
             if (p == null)
             {
                 MessageBox.Show(I18N.LangResource.errors.oops?.ToString(), I18N.LangResource.errors.error?.ToString());


### PR DESCRIPTION
THCRAP has recently released a new version of the configurator tool. It ships as a separate executable, `thcrap_configure_v3`, to keep the old one available for those who prefer it. However, new users are likely to start their thcrap experience with the new version of the configurator, and if they see the old one launched from UTL they might be *very* confused since it's not exactly intuitive or user-friendly. Hence, I propose that we switch the "open configurator" option to use `thcrap_configure_v3` instead of the old tool. I will also note that the old configurator can be launched *from* the new one (though not vice versa), so this doesn't remove the option of using the old one if the user prefers it.