### PR TITLE
Fix SplitterDistance not respecting config

### DIFF
--- a/Universal THCRAP Launcher/MainForm.cs
+++ b/Universal THCRAP Launcher/MainForm.cs
@@ -164,8 +164,6 @@ namespace Universal_THCRAP_Launcher
 
             #endregion
 
-            splitContainer1.SplitterDistance = Configuration1.SplitterDistance;
-
             #region Display
 
             //Change Form settings
@@ -174,6 +172,8 @@ namespace Universal_THCRAP_Launcher
             WindowState = Configuration1.WindowState;
 
             #endregion
+			
+			splitContainer1.SplitterDistance = Configuration1.SplitterDistance;
 
             ReadConfig();
 
@@ -198,7 +198,6 @@ namespace Universal_THCRAP_Launcher
         }
         private void SplitContainer1_SplitterMoved(object sender, SplitterEventArgs e)
         {
-            Configuration1.SplitterDistance = splitContainer1.SplitterDistance;
             try
             {
                 UpdateSplitContainerReleatedGui();


### PR DESCRIPTION
Currently, the window resize on launch cause the SplitterMoving function to trigger, which overwrites the SplitterDistance saved in the config. This causes the patch (left) panel to grow more every time the launcher starts.

It's not necessary to overwrite the config on every move of the splitter, because the function that saves the config already does that. This change correctly sets the SplitterDistance from the config on program start.